### PR TITLE
Revamp middleware

### DIFF
--- a/docs/advanced/middleware.md
+++ b/docs/advanced/middleware.md
@@ -4,18 +4,15 @@ Additional middleware can be written to perform a variety of tasks. For example,
 
 ## Defining Middleware
 
-To create a new middleware, create a new class and put your logic inside `__invoke` method:
+To create a new middleware, create a new `callable` class and put your logic inside `__invoke` method:
 
 ```php
-<?php
-
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 class AttachContentTypeRequestHeader
 {
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         if ($contentType = $request->body()->contentType()) {
             $request->headers()->with('Content-Type', $contentType);
@@ -31,13 +28,11 @@ In this middleware, we will add a content type header to the request depends on 
 Middleware also can be a `Closure`:
 
 ```php
-
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 function attach_content_type(string $contentType): Closure {
-    return function (Request $request, Closure $next): Response {
+    return function (Request $request, callable $next): Response {
         $request->headers()->with('Content-Type', $contentType);
 
         return $next($request);
@@ -54,15 +49,12 @@ You must call the `$next` callback with the `$request` to pass the request deepe
 Of course, a middleware can perform tasks before or after sending the request. For example, the following middleware would perform some task **before** the request is sent by the client:
 
 ```php
-<?php
-
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 class BeforeMiddleware
 {
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         // Perform action
 
@@ -74,15 +66,12 @@ class BeforeMiddleware
 However, this middleware would perform its task **after** the request is sent:
 
 ```php
-<?php
-
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 class AfterMiddleware
 {
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         $response = $next($request);
 
@@ -100,8 +89,6 @@ class AfterMiddleware
 To register default middleware, list the middleware class in the `defaultMiddleware` method of your connector class.
 
 ```php
-<?php
-
 use Jenky\Atlas\Connector as BaseConnector;
 
 class Connector extends BaseConnector
@@ -109,7 +96,7 @@ class Connector extends BaseConnector
     protected function defaultMiddleware(): array
     {
         return [
-            Middleware\AddCustomHeader::class,
+            new Middleware\AddCustomHeader(),
         ];
     }
 }

--- a/docs/advanced/response-decoder.md
+++ b/docs/advanced/response-decoder.md
@@ -6,7 +6,7 @@ HTTP response is a crucial aspect of web development, and it is essential to dec
 
 ### Configuring
 
-The decoder should be configured as per-request basis. By default `Jenky\Atlas\Request` uses [`Jenky\Atlas\Decoder\ChainDecoder`](https://github.com/jenky/atlas/blob/18f96c176bed75fa321df6a675146820760e295f/src/Request.php#L124-L130) to decode the response body. Essentially, it iterates over a list of `JsonDecoder` and `XmlDecoder` and attempts to read the `Content Type` header to determine which one to use for decoding the body.
+The decoder should be configured as per-request basis. By default `Jenky\Atlas\Request` uses [`ChainDecoder`](https://github.com/jenky/atlas/blob/18f96c176bed75fa321df6a675146820760e295f/src/Request.php#L124-L130) to decode the response body. Essentially, it iterates over a list of `JsonDecoder` and `XmlDecoder` and attempts to read the `Content Type` header to determine which one to use for decoding the body.
 
 ### Creating Custom Decoder
 

--- a/src/Contracts/PipelineInterface.php
+++ b/src/Contracts/PipelineInterface.php
@@ -26,10 +26,9 @@ interface PipelineInterface
     /**
      * Push additional pipes onto the pipeline.
      *
-     * @param  array|mixed  $pipes
      * @return static
      */
-    public function pipe($pipes);
+    public function pipe(callable ...$pipes);
 
     /**
      * Run the pipeline with a final destination callback.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -32,9 +32,9 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Unshift a middleware to the bottom of the stack.
      *
-     * @param  callable(Request, \Closure): Response|class-string  $middleware
+     * @param  callable(Request, callable): Response $middleware
      */
-    public function unshift($middleware, ?string $name = null): self
+    public function unshift(callable $middleware, ?string $name = null): self
     {
         array_unshift($this->middleware, [$middleware, $name]);
 
@@ -44,9 +44,9 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Push a middleware to stack.
      *
-     * @param  callable(Request, \Closure): Response|class-string  $middleware
+     * @param  callable(Request, callable): Response $middleware
      */
-    public function push($middleware, string $name = ''): self
+    public function push(callable $middleware, string $name = ''): self
     {
         $this->middleware[] = [$middleware, $name];
 
@@ -56,9 +56,9 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Prepend a middleware to the top of the stack.
      *
-     * @param  callable(Request, \Closure): Response|class-string  $middleware
+     * @param  callable(Request, callable): Response $middleware
      */
-    public function prepend($middleware, string $name = ''): self
+    public function prepend(callable $middleware, string $name = ''): self
     {
         array_unshift($this->middleware, [$middleware, $name]);
 
@@ -68,9 +68,9 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Add a middleware before another middleware by name.
      *
-     * @param  callable(Request, \Closure): Response|class-string  $middleware
+     * @param  callable(Request, callable): Response $middleware
      */
-    public function before(string $findName, $middleware, string $name = ''): self
+    public function before(string $findName, callable $middleware, string $name = ''): self
     {
         $this->splice($findName, $name, $middleware, true);
 
@@ -80,9 +80,9 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Add a middleware after another middleware by name.
      *
-     * @param  callable(Request, \Closure): Response|class-string  $middleware
+     * @param  callable(Request, callable): Response $middleware
      */
-    public function after(string $findName, $middleware, string $name = ''): self
+    public function after(string $findName, callable $middleware, string $name = ''): self
     {
         $this->splice($findName, $name, $middleware, false);
 
@@ -92,7 +92,7 @@ final class Middleware implements IteratorAggregate, Countable
     /**
      * Remove a middleware by instance or name from the stack.
      *
-     * @param  callable(Request, \Closure): Response|string  $remove
+     * @param  callable(Request, callable): Response|string  $remove
      */
     public function remove($remove): self
     {

--- a/src/Middleware/AttachContentTypeRequestHeader.php
+++ b/src/Middleware/AttachContentTypeRequestHeader.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Jenky\Atlas\Middleware;
 
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 final class AttachContentTypeRequestHeader
 {
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         if ($request->headers()->has('Content-Type')) {
             return $next($request);

--- a/src/Middleware/Interceptor.php
+++ b/src/Middleware/Interceptor.php
@@ -15,7 +15,7 @@ final class Interceptor
      */
     public static function request(Closure $callback): Closure
     {
-        return function (Request $request, Closure $next) use ($callback): Response {
+        return function (Request $request, callable $next) use ($callback): Response {
             $callback($request);
 
             return $next($request);
@@ -27,7 +27,7 @@ final class Interceptor
      */
     public static function response(Closure $callback): Closure
     {
-        return function (Request $request, Closure $next) use ($callback): Response {
+        return function (Request $request, callable $next) use ($callback): Response {
             $response = $next($request);
 
             $callback($response);

--- a/src/Middleware/RetryRequest.php
+++ b/src/Middleware/RetryRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Jenky\Atlas\Middleware;
 
-use Closure;
 use Jenky\Atlas\Contracts\RetryStrategyInterface;
 use Jenky\Atlas\Exceptions\RetryException;
 use Jenky\Atlas\Request;
@@ -29,7 +28,7 @@ final class RetryRequest
         $this->retryStrategy = $retryStrategy;
     }
 
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         $this->context->attempting();
 

--- a/src/Middleware/SetResponseDecoder.php
+++ b/src/Middleware/SetResponseDecoder.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Jenky\Atlas\Middleware;
 
-use Closure;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
 
 final class SetResponseDecoder
 {
-    public function __invoke(Request $request, Closure $next): Response
+    public function __invoke(Request $request, callable $next): Response
     {
         $response = $next($request);
 

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Jenky\Atlas\Tests;
 
-use Closure;
 use Jenky\Atlas\Middleware\Interceptor;
 use Jenky\Atlas\Request;
 use Jenky\Atlas\Response;
@@ -20,7 +19,7 @@ final class ConnectorTest extends TestCase
 
         $this->assertCount(1, $connector->middleware());
 
-        $connector->middleware()->push(function (Request $request, Closure $next): Response {
+        $connector->middleware()->push(function (Request $request, callable $next): Response {
             $request->headers()->with('Echo', 'Atlas');
             return $next($request);
         }, 'echo');
@@ -37,7 +36,7 @@ final class ConnectorTest extends TestCase
             $response->withHeader('X-Unique-Id', $id);
         }));
 
-        $connector->middleware()->prepend(function (Request $request, Closure $next): Response {
+        $connector->middleware()->prepend(function (Request $request, callable $next): Response {
             return $next($request);
         }, 'first');
 
@@ -52,7 +51,7 @@ final class ConnectorTest extends TestCase
 
         $this->assertCount(4, $connector->middleware());
 
-        $connector->middleware()->push(function (Request $request, Closure $next): Response {
+        $connector->middleware()->push(function (Request $request, callable $next): Response {
             $request->headers()->with('X-Foo', 'bar');
 
             return $next($request);

--- a/tests/Services/HTTPBin/Connector.php
+++ b/tests/Services/HTTPBin/Connector.php
@@ -27,7 +27,7 @@ final class Connector extends BaseConnector
     protected function defaultMiddleware(): array
     {
         return [
-            Middleware\AddCustomHeader::class,
+            new Middleware\AddCustomHeader(),
         ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Middleware now only accept `callable`

## Motivation and context

To make the api more simple and predictable, `class-string` is removed. Callable class is more flexible because it allows to pass constructor arguments.