### PR TITLE
Refactor configurator

### DIFF
--- a/src/ConnectorConfigurator.php
+++ b/src/ConnectorConfigurator.php
@@ -11,31 +11,44 @@ use Fansipan\Middleware\RetryRequests;
 use Fansipan\Retry\Delay;
 use Fansipan\Retry\GenericRetryStrategy;
 
+/**
+ * @template T of ConnectorInterface
+ */
 class ConnectorConfigurator
 {
     /**
-     * @var array<array-key, callable(\Psr\Http\Message\RequestInterface, callable): \Psr\Http\Message\ResponseInterface>
+     * @var \Closure[]
      */
-    protected $middleware = [];
+    private $handlers = [];
 
     /**
      * Configure the given connector with options for current request.
      *
-     * @template T of ConnectorInterface
      * @param  T $connector
      * @return T
      */
     final public function configure(ConnectorInterface $connector): ConnectorInterface
     {
-        if (empty($this->middleware)) {
-            return $connector;
-        }
-
         $clone = clone $connector;
 
-        foreach ($this->middleware as $name => $middleware) {
-            $clone->middleware()->unshift($middleware, \is_string($name) ? $name : '');
+        foreach ($this->handlers as $handler) {
+            $handler($clone);
         }
+
+        return $clone;
+    }
+
+    /**
+     * Register a configuration handler.
+     *
+     * @param  \Closure(T): void $handler
+     * @return static
+     */
+    protected function register(\Closure $handler)
+    {
+        $clone = clone $this;
+
+        $clone->handlers[] = $handler;
 
         return $clone;
     }
@@ -50,17 +63,13 @@ class ConnectorConfigurator
         ?RetryStrategyInterface $retryStrategy = null,
         bool $throw = true
     ) {
-        $strategy = $retryStrategy ?? new GenericRetryStrategy(new Delay(1000, 2.0));
-
-        $clone = clone $this;
-
-        $clone->middleware['retry_requests'] = new RetryRequests(
-            $strategy,
-            $maxRetries,
-            $throw
-        );
-
-        return $clone;
+        return $this->register(static function (ConnectorInterface $connector) use ($retryStrategy, $maxRetries, $throw) {
+            $strategy = $retryStrategy ?? new GenericRetryStrategy(new Delay(1000, 2.0));
+            $middleware = new RetryRequests($strategy, $maxRetries, $throw);
+            $connector->middleware()->unshift(
+                $middleware, 'retry_requests'
+            );
+        });
     }
 
     /**
@@ -75,15 +84,13 @@ class ConnectorConfigurator
         bool $strict = false,
         bool $referer = false
     ) {
-        $clone = clone $this;
-
-        $clone->middleware['follow_redirects'] = new FollowRedirects(
-            $max,
-            $protocols,
-            $strict,
-            $referer
-        );
-
-        return $clone;
+        return $this->register(static function (ConnectorInterface $connector) use ($max, $protocols, $strict, $referer) {
+            $connector->middleware()->unshift(new FollowRedirects(
+                $max,
+                $protocols,
+                $strict,
+                $referer
+            ), 'follow_redirects');
+        });
     }
 }

--- a/src/Traits/HasClient.php
+++ b/src/Traits/HasClient.php
@@ -12,7 +12,7 @@ trait HasClient
     /**
      * The HTTP client instance.
      *
-     * @var \Psr\Http\Client\ClientInterface
+     * @var ClientInterface
      */
     private $client;
 

--- a/src/Traits/HasMiddleware.php
+++ b/src/Traits/HasMiddleware.php
@@ -11,7 +11,7 @@ trait HasMiddleware
     /**
      * The middleware instance.
      *
-     * @var \Fansipan\Middleware
+     * @var Middleware
      */
     private $middleware;
 
@@ -40,7 +40,7 @@ trait HasMiddleware
      */
     private function gatherMiddleware(): array
     {
-        return array_filter(array_map(function (array $item) {
+        return array_filter(array_map(static function (array $item) {
             return $item[0] ?? null;
         }, $this->middleware()->all()));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `register` method was introduced to streamline middleware registration, improving extendability and encapsulation while allowing middleware to be added as closures which are lazily invoked during connector configuration. This change leads to cleaner code and a more scalable configuration pattern.