### PR TITLE
Handle undecodable responses gracefully

### DIFF
--- a/docs/retype.yml
+++ b/docs/retype.yml
@@ -4,7 +4,7 @@ url: phanxipang.github.io/fansipan
 
 branding:
   title: Fansipan
-  label: 1.0-RC1
+  label: 1.0-RC
 
 edit:
   repo: https://github.com/phanxipang/fansipan

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fansipan\Tests;
 
+use Fansipan\Exception\NotDecodableException;
 use Fansipan\Mock\MockClient;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Response;
@@ -75,5 +76,16 @@ final class ResponseTest extends TestCase
         $this->assertTrue($response->ok());
         $this->assertJson($json = \json_encode($response));
         $this->assertJsonStringEqualsJsonFile($file, $json);
+    }
+
+    public function test_response_without_decoder(): void
+    {
+        $response = new Response(MockResponse::create(''));
+
+        $this->expectException(NotDecodableException::class);
+
+        $response->decode();
+
+        $this->assertIsArray($response->data());
     }
 }


### PR DESCRIPTION
Introduced a try-catch block in the data() method to catch `NotDecodableException` when attempting to decode response data. In such cases, decoding will now default to an empty array instead of throwing an unhandled exception. Moreover, clarified method return types in doc comments for `onError`, `throw`, and `throwIf` to reflect the generic `Response<T>` type.
