### PR TITLE
Anonymous connectorless request

### DIFF
--- a/docs/basic/requests.md
+++ b/docs/basic/requests.md
@@ -492,17 +492,18 @@ $response = $connector->send($request);
 
 ### Sending Request without Connector
 
-While the typical setup of a connector and requests is great, sometimes all you need is to make a single request to a service. For scenarios like these, you may create a "`ConnectorlessRequest`" instead of making a connector and a single request. This saves you from having to create additional classes.
-
-!!!danger
-It is NOT recommended to send your requests without connector. Be aware of the [downsides](#downsides).
-!!!
-
-Create a request class, but instead of extending `Fansipan\Request`, you should extend `Fansipan\ConnectorlessRequest`. Next, just define everything else like you would a normal request. Make sure to include the full URL of the service you are integrating with.
+While the typical setup of a connector and requests is great, sometimes all you need is to make a single request to a service. For scenarios like these, you may create a `ConnectorlessRequest` instead of making a connector and a single request. This saves you from having to create additional classes.
 
 ```php
-<?php
+use Fansipan\ConnectorlessRequest;
 
+$request = ConnectorlessRequest::create('https://jsonplaceholder.typicode.com/users');
+$response = $request->send();
+```
+
+In case you needs constructor arguments on your request. Create a request class, but instead of extending `Fansipan\Request`, you should extend `Fansipan\ConnectorlessRequest`. Next, just define everything else like you would a normal request. Make sure to include the full URL of the service you are integrating with.
+
+```php
 use Fansipan\ConnectorlessRequest;
 
 final class GetUsersRequest extends ConnectorlessRequest

--- a/docs/basic/requests.md
+++ b/docs/basic/requests.md
@@ -494,6 +494,10 @@ $response = $connector->send($request);
 
 While the typical setup of a connector and requests is great, sometimes all you need is to make a single request to a service. For scenarios like these, you may create a `ConnectorlessRequest` instead of making a connector and a single request. This saves you from having to create additional classes.
 
+!!!danger
+It is NOT recommended to send your requests without connector. Be aware of the [downsides](#downsides).
+!!!
+
 ```php
 use Fansipan\ConnectorlessRequest;
 

--- a/src/ConnectorConfigurator.php
+++ b/src/ConnectorConfigurator.php
@@ -13,18 +13,17 @@ use Fansipan\Retry\GenericRetryStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * @template T of ConnectorInterface
- */
 class ConnectorConfigurator
 {
     /**
-     * @var array<\Closure(T): void>
+     * @var array<\Closure(ConnectorInterface): void>
      */
     private $handlers = [];
 
     /**
      * Configure the given connector with options for current request.
+     *
+     * @template T of ConnectorInterface
      *
      * @param  T $connector
      * @return T
@@ -58,7 +57,7 @@ class ConnectorConfigurator
     /**
      * Register a configuration handler.
      *
-     * @param  \Closure(T): void $handler
+     * @param  \Closure(ConnectorInterface): void $handler
      * @return static
      */
     protected function register(\Closure $handler)

--- a/src/ConnectorlessRequest.php
+++ b/src/ConnectorlessRequest.php
@@ -4,13 +4,53 @@ declare(strict_types=1);
 
 namespace Fansipan;
 
+use Fansipan\Contracts\ConnectorInterface;
+
 abstract class ConnectorlessRequest extends Request
 {
     /**
      * Send the request.
      */
-    final public function send(): Response
+    final public function send(?ConnectorInterface $connector = null): Response
     {
-        return (new GenericConnector())->send($this);
+        $connector = $connector ?: new GenericConnector();
+
+        return $connector->send($this);
+    }
+
+    /**
+     * @param  string|\Stringable $endpoint
+     */
+    public static function create($endpoint, string $method = 'GET'): self
+    {
+        return new class ((string) $endpoint, $method) extends ConnectorlessRequest {
+            /**
+             * @var string
+             */
+            private $endpoint;
+
+            /**
+             * @var string
+             */
+            private $method;
+
+            public function __construct(
+                string $endpoint,
+                string $method = 'GET'
+            ) {
+                $this->endpoint = $endpoint;
+                $this->method = $method;
+            }
+
+            public function endpoint(): string
+            {
+                return $this->endpoint;
+            }
+
+            public function method(): string
+            {
+                return $this->method;
+            }
+        };
     }
 }

--- a/src/ConnectorlessRequest.php
+++ b/src/ConnectorlessRequest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Fansipan;
 
-use Fansipan\Contracts\ConnectorInterface;
+use Http\Discovery\Psr18ClientDiscovery;
+use Psr\Http\Client\ClientInterface;
 
 abstract class ConnectorlessRequest extends Request
 {
     /**
      * Send the request.
      */
-    final public function send(?ConnectorInterface $connector = null): Response
+    final public function send(?ClientInterface $client = null): Response
     {
-        $connector = $connector ?: new GenericConnector();
+        $client = $client ?: Psr18ClientDiscovery::find();
 
-        return $connector->send($this);
+        $response = $client->sendRequest(Util::request($this));
+
+        return new Response($response, $this->decoder());
     }
 
     /**

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Fansipan\Tests;
 
-use Fansipan\GenericConnector;
 use Fansipan\Middleware\Auth\BasicAuthentication;
 use Fansipan\Middleware\Auth\BearerAuthentication;
 use Fansipan\Mock\MockClient;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Tests\Services\DummyRequest;
+use Fansipan\Tests\Services\GenericConnector;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Fansipan\Tests;
 
 use Fansipan\ConnectorConfigurator;
-use Fansipan\GenericConnector;
 use Fansipan\Middleware\Interceptor;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Mock\ScopingMockClient;
 use Fansipan\Tests\Services\DummyRequest;
+use Fansipan\Tests\Services\GenericConnector;
 use Fansipan\Tests\Services\PostmanEcho\EchoConnector;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/FollowRedirectsTest.php
+++ b/tests/FollowRedirectsTest.php
@@ -6,11 +6,11 @@ namespace Fansipan\Tests;
 
 use Fansipan\ConnectorConfigurator;
 use Fansipan\Exception\TooManyRedirectsException;
-use Fansipan\GenericConnector;
 use Fansipan\Middleware\FollowRedirects;
 use Fansipan\Mock\MockClient;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Tests\Services\DummyRequest;
+use Fansipan\Tests\Services\GenericConnector;
 
 final class FollowRedirectsTest extends TestCase
 {

--- a/tests/MapperTest.php
+++ b/tests/MapperTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Fansipan\Tests;
 
 use Fansipan\Contracts\MapperInterface;
-use Fansipan\GenericConnector;
 use Fansipan\Mock\MockClient;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Tests\Services\DummyRequest;
+use Fansipan\Tests\Services\GenericConnector;
 use Fansipan\Tests\Services\JsonPlaceholder\Error;
 use Fansipan\Tests\Services\JsonPlaceholder\GetUserRequest;
 use Fansipan\Tests\Services\JsonPlaceholder\User;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -175,13 +175,12 @@ final class RequestTest extends TestCase
     public function test_connectorless_request(): void
     {
         $client = new MockClient();
-        $connector = $this->connector->withClient($client);
 
-        $response = (new DummyRequest('https://example.com'))->send($connector);
+        $response = (new DummyRequest('https://example.com'))->send($client);
 
         $this->assertTrue($response->successful());
 
-        $response = ConnectorlessRequest::create('https://example.org')->send($connector);
+        $response = ConnectorlessRequest::create('https://example.org')->send($client);
 
         $this->assertTrue($response->successful());
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Fansipan\Tests;
 
 use Fansipan\Body\MultipartResource;
+use Fansipan\ConnectorlessRequest;
 use Fansipan\Exception\HttpException;
 use Fansipan\Mock\MockClient;
 use Fansipan\Mock\MockResponse;
 use Fansipan\Response;
+use Fansipan\Tests\Services\DummyRequest;
 use Fansipan\Tests\Services\HTTPBin\Connector;
 use Fansipan\Tests\Services\HTTPBin\DTO\Uuid;
 use Fansipan\Tests\Services\HTTPBin\GetHeadersRequest;
@@ -168,5 +170,19 @@ final class RequestTest extends TestCase
         });
 
         $connector->send($request->withStatus(200))->throwIf(true);
+    }
+
+    public function test_connectorless_request(): void
+    {
+        $client = new MockClient();
+        $connector = $this->connector->withClient($client);
+
+        $response = (new DummyRequest('https://example.com'))->send($connector);
+
+        $this->assertTrue($response->successful());
+
+        $response = ConnectorlessRequest::create('https://example.org')->send($connector);
+
+        $this->assertTrue($response->successful());
     }
 }

--- a/tests/Services/GenericConnector.php
+++ b/tests/Services/GenericConnector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fansipan;
+namespace Fansipan\Tests\Services;
 
 use Fansipan\Contracts\ConnectorInterface;
 use Fansipan\Traits\ConnectorTrait;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create `ConnectorlessRequest` directly via `ConnectorlessRequest::create` by utilizing an anonymous class.

## Motivation and context

This allows developer quickly create connectorless request without creating a new class.